### PR TITLE
Update plots.py

### DIFF
--- a/peakfit/plots.py
+++ b/peakfit/plots.py
@@ -59,7 +59,7 @@ def plot_pdf(
     # Create the figure
     fig = plt.figure()
     ax = fig.add_subplot(111)
-
+    fig.set_size_inches(2*len(cluster.peaks),3*len(cluster.peaks))
     params = out.params
     peaks = cluster.peaks
     x_pts = [params[f"p{i}_x0_pt"].value for i in range(len(peaks))]
@@ -74,7 +74,8 @@ def plot_pdf(
     # Plot the peak positions
     ax.scatter(x_pts_init, y_pts_init, color=SCATTER_COLOR_1, s=20, label="Initial")
     ax.scatter(x_pts, y_pts, color=SCATTER_COLOR_2, s=20, label="Fit")
-
+    for bla in range(len(peaks['name'])):
+        plt.annotate(peaks['name'][bla],xy=(x_pts[bla],y_pts[bla]),size=10)  #adds the peak name next to the fitted peak position
     # Print chi2 and reduced chi2
     chi2red_str = r"$\chi^2_{red}$:"
     ax.text(


### PR DESCRIPTION
added a figure_size in case of clusters. could be put into an "if len(cluster.peaks)>threshold"  

added peaks labels next to fitted peaks

<!--- Provide a general summary of your changes in the Title above -->

## Description
#when defining the figure, added this line, to scale fig_size to the number of peaks (len(cluster.peaks))
fig.set_size_inches(2*len(cluster.peaks),3*len(cluster.peaks))


# after the peak labelling, added this loop to print the peak label next to the fitted peak positions (x_pts[peak],y_pts[bla])
for bla in range(len(peaks['name'])):
        plt.annotate(peaks['name'][bla],xy=(x_pts[bla],y_pts[bla]),size=10)  #adds the peak name


<!--- Describe your changes in detail -->

## Motivation and Context

I have big clusters (working on IDP). in the printout, they are poorly resolved, and having only the peaknames as a list in the title makes it ambiguous to observe
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I modified plots.py on my computer and ran the fit. I originally put "5*cluster, 6*cluster" as dimensions but that makes the print too big. maybe I should just put the scaling in a "if" 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
[clusters.pdf](https://github.com/user-attachments/files/15791556/clusters.pdf)
