### PR TITLE
Normalize ANSI in CLI help assertions

### DIFF
--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,21 +1,27 @@
+from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from peakfit.cli.app import app
 
 
-def test_root_help_uses_pseudo_nd_terminology() -> None:
-    result = CliRunner().invoke(app, ["--help"])
+def rendered_help(*args: str) -> str:
+    result = CliRunner().invoke(app, [*args, "--help"])
 
     assert result.exit_code == 0, result.output
-    assert "pseudo-ND NMR spectra" in result.output
-    assert "pseudo-3D" not in result.output
+    return strip_ansi(result.output)
+
+
+def test_root_help_uses_pseudo_nd_terminology() -> None:
+    help_text = rendered_help()
+
+    assert "pseudo-ND NMR spectra" in help_text
+    assert "pseudo-3D" not in help_text
 
 
 def test_fit_help_describes_plane_values_without_renaming_the_option() -> None:
-    result = CliRunner().invoke(app, ["fit", "--help"])
+    help_text = rendered_help("fit")
 
-    assert result.exit_code == 0, result.output
-    assert "pseudo-ND NMR spectrum" in result.output
-    assert "--z-values" in result.output
-    assert "Plane values file" in result.output
-    assert "Z-dimension" not in result.output
+    assert "pseudo-ND NMR spectrum" in help_text
+    assert "--z-values" in help_text
+    assert "Plane values file" in help_text
+    assert "Z-dimension" not in help_text


### PR DESCRIPTION
Strips ANSI styling from captured Typer help before asserting visible terminology. Fixes the Linux CI failure without changing CLI behavior.